### PR TITLE
Rendre compatible ce bundle avec Symfony 5.4

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,13 +12,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('grunt_hash_assets');
+        $treeBuilder = new TreeBuilder('grunt_hash_assets');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()
                 ->scalarNode('assets_dir')
-                    ->defaultValue('%kernel.root_dir%/../web/assets/')
+                    ->defaultValue('%kernel.project_dir%/public/assets/')
                 ->end()
                 ->scalarNode('assets_base_path')
                     ->defaultValue('/assets')

--- a/Twig/Assets.php
+++ b/Twig/Assets.php
@@ -3,8 +3,10 @@
 namespace Agallou\GruntHashAssetsBundle\Twig;
 
 use Symfony\Component\Finder\Finder;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class Assets extends \Twig_Extension
+class Assets extends AbstractExtension
 {
     /**
      * @var string
@@ -32,7 +34,7 @@ class Assets extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('grunt_asset', array($this, 'gruntAsset')),
+            new TwigFunction('grunt_asset', array($this, 'gruntAsset')),
         );
     }
 


### PR DESCRIPTION
Deux changements apportés pour que ce bundle fonctionne avec Symfony 5.4 :
* la déclaration de la configuration

> A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0

* La modification de méthodes liées à la version 3 de Twig

> Using the "Twig_Extension" class is deprecated since Twig version 2.7, use "Twig\Extension\AbstractExtension" instead.

> As of Twig 2.x, the Twig_SimpleFunction class is deprecated and will be removed in Twig 3.x (use \Twig\TwigFunction instead). In Twig 2.x, Twig_SimpleFunction is just an alias for \Twig\TwigFunction.